### PR TITLE
Add upcoming events display to Events console

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "88",
+       "version": "89",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/EventsScrollBox/GameEventsUpcoming.lua
+++ b/src/scripts/GMCP/EventsScrollBox/GameEventsUpcoming.lua
@@ -1,0 +1,45 @@
+-- Handler for Game.Events.Upcoming GMCP package
+-- Lists all upcoming events sorted by start time
+
+-- Initialize upcoming events storage
+upcomingEvents = upcomingEvents or {}
+
+function GameEventsUpcoming(event, gmcp_data)
+    -- Get the data from gmcp table
+    local data = gmcp.Game and gmcp.Game.Events and gmcp.Game.Events.Upcoming
+    
+    -- If no data available, clear upcoming events and return
+    if not data or type(data) ~= "table" then
+        upcomingEvents = {}
+        return
+    end
+    
+    -- Clear and rebuild upcoming events list
+    upcomingEvents = {}
+    
+    for _, event_data in ipairs(data) do
+        if event_data.event_id then
+            table.insert(upcomingEvents, {
+                event_id = event_data.event_id,
+                event_name = event_data.event_name,
+                event_type = event_data.event_type,
+                start_time = event_data.start_time,
+                end_time = event_data.end_time,
+                description = event_data.description
+            })
+        end
+    end
+    
+    -- Sort by start_time in ascending order
+    table.sort(upcomingEvents, function(a, b)
+        return a.start_time < b.start_time
+    end)
+    
+    -- Only rebuild the display if EventsScrollBox is currently selected
+    if selected_console == "EventsScrollBox" then
+        CharEventsList()
+    end
+end
+
+-- Register the event handler
+registerAnonymousEventHandler("gmcp.Game.Events.Upcoming", "GameEventsUpcoming")

--- a/src/scripts/GMCP/EventsScrollBox/scripts.json
+++ b/src/scripts/GMCP/EventsScrollBox/scripts.json
@@ -29,6 +29,15 @@
        {
               "isActive": "yes",
               "isFolder": "no",
+              "name": "GameEventsUpcoming",
+              "eventHandlerList": [
+                     "gmcp.Game.Events.Upcoming"
+              ],
+              "script": ""
+       },
+       {
+              "isActive": "yes",
+              "isFolder": "no",
               "name": "CharEventsSession",
               "eventHandlerList": [
                      "gmcp.Char.Events.Session"


### PR DESCRIPTION
- Created GameEventsUpcoming.lua to handle gmcp.Game.Events.Upcoming
- Added formatTimeUntilStart() helper function for countdown display
- Upcoming events now display in same table as active events
- Events sorted by start_time in ascending order
- Timer updates both active and upcoming event countdowns
- Registered GameEventsUpcoming handler in scripts.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of upcoming events with countdown timers showing time until events begin.
  * Enhanced event information display to include progress details such as kills, ranks, and collection items.

* **Chores**
  * Updated version to 89.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->