### PR TITLE
Add days display to active event time remaining

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "89",
+       "version": "90",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/EventsScrollBox/CharEventsList.lua
+++ b/src/scripts/GMCP/EventsScrollBox/CharEventsList.lua
@@ -119,11 +119,14 @@ local function formatTimeRemaining(endTime)
         return "<font color=\"red\">Ended</font>", true  -- Return true to indicate event ended
     end
     
-    local hours = math.floor(remaining / 3600)
+    local days = math.floor(remaining / 86400)
+    local hours = math.floor((remaining % 86400) / 3600)
     local minutes = math.floor((remaining % 3600) / 60)
     local seconds = remaining % 60
     
-    if hours > 0 then
+    if days > 0 then
+        return string.format("<font color=\"yellow\">%d</font><font color=\"white\">d</font> <font color=\"yellow\">%d</font><font color=\"white\">h</font> <font color=\"yellow\">%d</font><font color=\"white\">m remaining</font>", days, hours, minutes), false
+    elseif hours > 0 then
         return string.format("<font color=\"yellow\">%d</font><font color=\"white\">h</font> <font color=\"yellow\">%d</font><font color=\"white\">m</font> <font color=\"yellow\">%d</font><font color=\"white\">s remaining</font>", hours, minutes, seconds), false
     elseif minutes > 0 then
         return string.format("<font color=\"yellow\">%d</font><font color=\"white\">m</font> <font color=\"yellow\">%d</font><font color=\"white\">s remaining</font>", minutes, seconds), false


### PR DESCRIPTION
- Updated formatTimeRemaining() to show days when events have 24+ hours left
- Consistent with formatTimeUntilStart() for upcoming events
- Format: '2d 5h 30m remaining' for multi-day events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event countdown timers now display remaining days in addition to hours and minutes with improved formatting for better visibility of event durations.

* **Chores**
  * Version updated to 90.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->