### PR TITLE
Fix section headers not showing when labels are reused 

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "93",
+       "version": "94",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
@@ -125,6 +125,7 @@ local function createSectionHeader(index, yPos, title)
         GUI.GamePlayersListRows[index]:resize("100%", rowHeight .. "px")
         GUI.GamePlayersListRows[index]:move(0, yPos .. "px")
         GUI.GamePlayersListRows[index]:echo(content)
+        GUI.GamePlayersListRows[index]:show()
     else
         GUI.GamePlayersListRows[index] = Geyser.Label:new({
             name = rowName,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where player list headers would not display properly when reused.

* **Chores**
  * Version updated to 94.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->