### PR TITLE
Fix popup labels by properly deleting them instead of just hiding

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "101",
+       "version": "102",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -169,11 +169,14 @@ function GamePlayersInfo()
     -- Resize popup
     GUI.PlayerDetailPopup:resize(nil, totalHeight)
     
-    -- Clear existing labels
+    -- Clear existing labels (destroy them, not just hide)
     if GUI.PlayerDetailPopupLabels then
         for _, label in ipairs(GUI.PlayerDetailPopupLabels) do
             if label then
                 label:hide()
+                if label.delete then
+                    label:delete()
+                end
             end
         end
     end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
@@ -28,11 +28,14 @@ function ClosePlayerDetailPopup()
         GUI.PlayerPopupClickHandler = nil
     end
     
-    -- Clean up labels
+    -- Clean up labels (destroy them, not just hide)
     if GUI.PlayerDetailPopupLabels then
         for _, label in ipairs(GUI.PlayerDetailPopupLabels) do
             if label then
                 label:hide()
+                if label.delete then
+                    label:delete()
+                end
             end
         end
         GUI.PlayerDetailPopupLabels = nil


### PR DESCRIPTION
- Call label:delete() when clearing labels to prevent reuse issues
- Fixes clan row disappearing on second popup open