### PR TITLE
Refactor popup labels to use reuse pattern like player list

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "102",
+       "version": "103",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -169,49 +169,62 @@ function GamePlayersInfo()
     -- Resize popup
     GUI.PlayerDetailPopup:resize(nil, totalHeight)
     
-    -- Clear existing labels (destroy them, not just hide)
+    -- Hide any extra labels from previous render
     if GUI.PlayerDetailPopupLabels then
-        for _, label in ipairs(GUI.PlayerDetailPopupLabels) do
-            if label then
-                label:hide()
-                if label.delete then
-                    label:delete()
-                end
+        for i = #rows + 1, #GUI.PlayerDetailPopupLabels do
+            if GUI.PlayerDetailPopupLabels[i] then
+                GUI.PlayerDetailPopupLabels[i]:hide()
             end
         end
+    else
+        GUI.PlayerDetailPopupLabels = {}
     end
-    GUI.PlayerDetailPopupLabels = {}
     
-    -- Create individual labels for each row with absolute positioning
+    -- Create or update labels for each row with absolute positioning
     local currentY = padding
     for i, row in ipairs(rows) do
         local labelName = "GUI.PlayerDetailPopupRow" .. i
-        local label = Geyser.Label:new({
-            name = labelName,
-            x = 0,
-            y = currentY .. "px",
-            width = "100%",
-            height = row.height .. "px",
-        }, GUI.PlayerDetailPopup)
         
-        label:setStyleSheet([[
-            background-color: transparent;
-        ]])
-        
-        label:echo(row.content)
-        
-        -- Apply link style if specified
-        if row.linkStyle then
-            label:setLinkStyle(row.linkStyle[1], row.linkStyle[2], row.linkStyle[3])
+        if GUI.PlayerDetailPopupLabels[i] then
+            -- Reuse existing label
+            GUI.PlayerDetailPopupLabels[i]:move(0, currentY .. "px")
+            GUI.PlayerDetailPopupLabels[i]:resize("100%", row.height .. "px")
+            GUI.PlayerDetailPopupLabels[i]:echo(row.content)
+            if row.linkStyle then
+                GUI.PlayerDetailPopupLabels[i]:setLinkStyle(row.linkStyle[1], row.linkStyle[2], row.linkStyle[3])
+            end
+            GUI.PlayerDetailPopupLabels[i]:show()
+            GUI.PlayerDetailPopupLabels[i]:raise()
+        else
+            -- Create new label
+            local label = Geyser.Label:new({
+                name = labelName,
+                x = 0,
+                y = currentY .. "px",
+                width = "100%",
+                height = row.height .. "px",
+            }, GUI.PlayerDetailPopup)
+            
+            label:setStyleSheet([[
+                background-color: transparent;
+            ]])
+            
+            label:echo(row.content)
+            
+            -- Apply link style if specified
+            if row.linkStyle then
+                label:setLinkStyle(row.linkStyle[1], row.linkStyle[2], row.linkStyle[3])
+            end
+            
+            -- Prevent clicks from closing the popup
+            label:setClickCallback(function() end)
+            
+            label:show()
+            label:raise()
+            
+            GUI.PlayerDetailPopupLabels[i] = label
         end
         
-        -- Prevent clicks from closing the popup
-        label:setClickCallback(function() end)
-        
-        label:show()
-        label:raise()
-        
-        GUI.PlayerDetailPopupLabels[i] = label
         currentY = currentY + row.height
     end
 end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
@@ -28,14 +28,11 @@ function ClosePlayerDetailPopup()
         GUI.PlayerPopupClickHandler = nil
     end
     
-    -- Clean up labels (destroy them, not just hide)
+    -- Clean up labels (hide them)
     if GUI.PlayerDetailPopupLabels then
         for _, label in ipairs(GUI.PlayerDetailPopupLabels) do
             if label then
                 label:hide()
-                if label.delete then
-                    label:delete()
-                end
             end
         end
         GUI.PlayerDetailPopupLabels = nil


### PR DESCRIPTION
- Reuse existing labels by updating move/resize/echo/show
- Hide extra labels when row count decreases
- Remove label delete calls in favor of reuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized player detail popup performance by improving how information elements are managed and displayed. Interface labels are now reused efficiently rather than being constantly recreated, resulting in enhanced responsiveness and reduced memory consumption during gameplay and player list interactions.

* **Chores**
  * Version bumped to 103.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->