### PR TITLE
Add AFK status indicator and OPK tag to player detail popup

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "106",
+       "version": "107",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "105",
+       "version": "106",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/Initialize.lua
+++ b/src/scripts/GMCP/Initialize.lua
@@ -25,6 +25,41 @@ tempTimer(
 )
 
 -- Request GMCP data from server (will update GUI when responses arrive)
+
+-- Declare supported GMCP packages to the server
+local packages = {
+    -- Core
+    "Core 1",
+
+    -- Character
+    "Char 1",
+    "Char.Vitals 1",          -- CharVitals.lua
+    "Char.Status 1",          -- CharStatus.lua
+    "Char.Items 1",           -- Inventory and Room item handlers
+    "Char.Abilities 1",       -- AbilitiesButtons handlers
+    "Char.Help 1",            -- HelpContainer/CharHelpList.lua
+    "Char.Guild.Help 1",      -- AbilitiesConsole/CharGuildHelpList.lua
+    "Char.Training 1",        -- TrainingScrollBox handlers
+    "Char.Events 1",          -- EventsScrollBox/CharEventsList.lua
+
+    -- Room
+    "Room 1",                 -- RoomInfo.lua, Room.Players handlers
+
+    -- Communication
+    "Comm 1",
+    "Comm.Channel 1",         -- CommChannelText.lua
+
+    -- Group
+    "Group 1",                -- GroupScrollBox/Group.lua
+
+    -- Game
+    "Game 1",
+    "Game.Players 1",         -- PlayersScrollBox handlers
+    "Game.Events 1",          -- EventsScrollBox/GameEvents handlers
+    "Game.Info 1",            -- InfoScrollBox/GameInfo.lua
+}
+sendGMCP("Core.Supports.Add " .. yajl.to_string(packages))
+
 sendGMCP("Char.Vitals")
 sendGMCP("Char.Status")
 sendGMCP("Game.Players.List")

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -240,13 +240,13 @@ function GamePlayersInfo()
     if info.afk ~= nil then
         local statusLabelName = "GUI.PlayerDetailPopupAFKStatus"
         
-        -- Calculate position (lower-right, outside avatar)
+        -- Calculate position (bottom-right corner of avatar)
         local popupWidth = GUI.PlayerDetailPopup:get_width()
         local avatarHalfWidth = 32  -- 64px / 2
         local avatarSize = 64
-        local statusSize = 20
-        local statusX = (popupWidth / 2) + avatarHalfWidth - 4  -- Slightly to the right of avatar
-        local statusY = padding + avatarSize - 8  -- Slightly below avatar bottom
+        local statusSize = 16  -- Smaller size for less intrusion
+        local statusX = (popupWidth / 2) + avatarHalfWidth - statusSize - 2  -- Inside avatar right edge
+        local statusY = padding + avatarSize - statusSize - 2  -- Inside avatar bottom edge
         
         -- Always recreate the label to ensure it displays properly
         if GUI.PlayerDetailPopupAFKStatus then
@@ -264,18 +264,18 @@ function GamePlayersInfo()
         
         -- Set style and content based on AFK status
         if info.afk == 0 then
-            -- Active - green filled circle
+            -- Active - green filled circle with shadow for depth
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
                 background-color: #00ff00;
-                border: 2px solid #333;
-                border-radius: 10px;
+                border: 2px solid #006600;
+                border-radius: 8px;
             ]])
         elseif info.afk == 1 then
             -- Away - crescent moon emoji
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
                 background-color: transparent;
                 border: none;
-                font-size: 16px;
+                font-size: 14px;
             ]])
             GUI.PlayerDetailPopupAFKStatus:echo([[<center>🌙</center>]])
         end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -29,24 +29,12 @@ function GamePlayersInfo()
     -- Build list of content rows to determine height
     local rows = {}
     
-    -- Avatar row with AFK status indicator
-    local statusIndicator = ""
-    if info.afk then
-        if info.afk == 0 then
-            -- Active - green filled circle
-            statusIndicator = [[<div style="position: absolute; top: 2px; right: 2px; width: 16px; height: 16px; background-color: #00ff00; border-radius: 50%; border: 2px solid #333;"></div>]]
-        elseif info.afk == 1 then
-            -- Away - yellow/orange crescent
-            statusIndicator = [[<div style="position: absolute; top: 2px; right: 2px; font-size: 16px; text-shadow: 0 0 3px #333;">🌙</div>]]
-        end
-    end
-    
+    -- Avatar row
     table.insert(rows, {
         height = avatarHeight,
         content = string.format(
-            [[<center><div style="position: relative; display: inline-block;"><img src="%s" width="64" height="64">%s</div></center>]],
-            getGuildImagePath(info.guild, info.gender),
-            statusIndicator
+            [[<center><img src="%s" width="64" height="64"></center>]],
+            getGuildImagePath(info.guild, info.gender)
         )
     })
     
@@ -247,5 +235,52 @@ function GamePlayersInfo()
         end
         
         currentY = currentY + row.height
+    end
+    
+    -- Create/update AFK status indicator overlay on avatar
+    if info.afk ~= nil then
+        local statusLabelName = "GUI.PlayerDetailPopupAFKStatus"
+        
+        -- Calculate position (top-right corner of avatar)
+        -- Avatar is centered in popup, 64px wide, popup is likely ~200px wide
+        local avatarCenterX = "50%"
+        local statusX = "50%"  -- Center of popup
+        local statusXOffset = 22  -- Half avatar width (32px) minus half status size (10px)
+        local statusY = padding + 2  -- Just inside the avatar top edge
+        
+        if not GUI.PlayerDetailPopupAFKStatus then
+            GUI.PlayerDetailPopupAFKStatus = Geyser.Label:new({
+                name = statusLabelName,
+                x = statusX,
+                y = statusY .. "px",
+                width = "20px",
+                height = "20px",
+            }, GUI.PlayerDetailPopup)
+        else
+            GUI.PlayerDetailPopupAFKStatus:move(statusX, statusY .. "px")
+            GUI.PlayerDetailPopupAFKStatus:resize("20px", "20px")
+        end
+        
+        if info.afk == 0 then
+            -- Active - green filled circle
+            GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
+                background-color: #00ff00;
+                border: 2px solid #333;
+                border-radius: 10px;
+            ]])
+        elseif info.afk == 1 then
+            -- Away - crescent moon emoji
+            GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
+                background-color: transparent;
+                border: none;
+                font-size: 16px;
+            ]])
+            GUI.PlayerDetailPopupAFKStatus:echo([[<center>🌙</center>]])
+        end
+        
+        GUI.PlayerDetailPopupAFKStatus:show()
+        GUI.PlayerDetailPopupAFKStatus:raise()
+    elseif GUI.PlayerDetailPopupAFKStatus then
+        GUI.PlayerDetailPopupAFKStatus:hide()
     end
 end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -47,25 +47,15 @@ function GamePlayersInfo()
         )
     })
     
-    -- Race/Guild/Level row with OPK tag
-    local opkTag = ""
-    if info.opt_in_pk and info.opt_in_pk == 1 then
-        opkTag = string.format(
-            [[ <a href="send:pkinfo %s"><span style="background-color: blue; color: yellow; padding: 1px 4px; font-weight: bold; border-radius: 2px;">OPK</span></a>]],
-            info.name:lower()
-        )
-    end
-    
+    -- Race/Guild/Level row
     table.insert(rows, {
         height = infoLineHeight,
         content = string.format(
-            [[<center><font size="3" color="silver">%s %s - Level %d%s</font></center>]],
+            [[<center><font size="3" color="silver">%s %s - Level %d</font></center>]],
             firstToUpper(info.race),
             firstToUpper(info.guild),
-            info.level,
-            opkTag
-        ),
-        linkStyle = info.opt_in_pk == 1 and {"yellow", "yellow", false} or nil
+            info.level
+        )
     })
     
     -- Alignment row
@@ -76,6 +66,18 @@ function GamePlayersInfo()
                 [[<center><font size="3" color="gray">%s</font></center>]],
                 firstToUpper(info.alignment)
             )
+        })
+    end
+    
+    -- OPK (Opt-in Player Kill) tag row
+    if info.opt_in_pk and info.opt_in_pk == 1 then
+        table.insert(rows, {
+            height = infoLineHeight,
+            content = string.format(
+                [[<center> <a href="send:pkinfo %s"><span style="background-color: red; color: white; padding: 1px 4px; font-weight: bold; border-radius: 2px;">OPK</span></a></center>]],
+                info.name:lower()
+            ),
+            linkStyle = {"white", "white", false}
         })
     end
     
@@ -241,12 +243,13 @@ function GamePlayersInfo()
     if info.afk ~= nil then
         local statusLabelName = "GUI.PlayerDetailPopupAFKStatus"
         
-        -- Calculate position (top-right corner of avatar)
+        -- Calculate position (bottom-right corner of avatar)
         local popupWidth = GUI.PlayerDetailPopup:get_width()
         local avatarHalfWidth = 32  -- 64px / 2
+        local avatarSize = 64
         local statusSize = 20
         local statusX = (popupWidth / 2) + avatarHalfWidth - statusSize
-        local statusY = padding + 2
+        local statusY = padding + avatarSize - statusSize - 2  -- Position at bottom of avatar
         
         -- Always recreate the label to ensure it displays properly
         if GUI.PlayerDetailPopupAFKStatus then

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -271,11 +271,12 @@ function GamePlayersInfo()
                 border-radius: 8px;
             ]])
         elseif info.afk == 1 then
-            -- Away - crescent moon emoji
+            -- Away - dark blue circle with moon emoji
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
-                background-color: transparent;
-                border: none;
-                font-size: 14px;
+                background-color: #1a237e;
+                border: 2px solid #0d1440;
+                border-radius: 8px;
+                font-size: 10px;
             ]])
             GUI.PlayerDetailPopupAFKStatus:echo([[<center>🌙</center>]])
         end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -237,6 +237,12 @@ function GamePlayersInfo()
         currentY = currentY + row.height
     end
     
+    -- Raise AFK status label if it exists to ensure it stays on top of row labels
+    if GUI.PlayerDetailPopupAFKStatus then
+        GUI.PlayerDetailPopupAFKStatus:raise()
+        cecho("\n<magenta>DEBUG: Re-raising AFK status label after row labels\n")
+    end
+    
     -- Create/update AFK status indicator overlay on avatar
     if info.afk ~= nil then
         cecho(string.format("\n<green>DEBUG: Showing AFK indicator for %s, afk=%d\n", info.name, info.afk))

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -237,50 +237,34 @@ function GamePlayersInfo()
         currentY = currentY + row.height
     end
     
-    -- Raise AFK status label if it exists to ensure it stays on top of row labels
-    if GUI.PlayerDetailPopupAFKStatus then
-        GUI.PlayerDetailPopupAFKStatus:raise()
-        cecho("\n<magenta>DEBUG: Re-raising AFK status label after row labels\n")
-    end
-    
     -- Create/update AFK status indicator overlay on avatar
     if info.afk ~= nil then
-        cecho(string.format("\n<green>DEBUG: Showing AFK indicator for %s, afk=%d\n", info.name, info.afk))
-        
         local statusLabelName = "GUI.PlayerDetailPopupAFKStatus"
         
         -- Calculate position (top-right corner of avatar)
-        -- Get popup dimensions to calculate proper positioning
         local popupWidth = GUI.PlayerDetailPopup:get_width()
-        local popupHeight = GUI.PlayerDetailPopup:get_height()
-        
-        -- Avatar is 64px centered, status indicator is 20px
-        -- Position at top-right corner of avatar
         local avatarHalfWidth = 32  -- 64px / 2
         local statusSize = 20
         local statusX = (popupWidth / 2) + avatarHalfWidth - statusSize
-        local statusY = padding + 2  -- Just inside the avatar top edge
+        local statusY = padding + 2
         
-        if not GUI.PlayerDetailPopupAFKStatus then
-            cecho("\n<yellow>DEBUG: Creating new AFK status label\n")
-            GUI.PlayerDetailPopupAFKStatus = Geyser.Label:new({
-                name = statusLabelName,
-                x = statusX,
-                y = statusY,
-                width = statusSize,
-                height = statusSize,
-            }, GUI.PlayerDetailPopup)
-        else
-            cecho("\n<cyan>DEBUG: Updating existing AFK status label\n")
-            GUI.PlayerDetailPopupAFKStatus:move(statusX, statusY)
-            GUI.PlayerDetailPopupAFKStatus:resize(statusSize, statusSize)
+        -- Always recreate the label to ensure it displays properly
+        if GUI.PlayerDetailPopupAFKStatus then
+            GUI.PlayerDetailPopupAFKStatus:hide()
+            GUI.PlayerDetailPopupAFKStatus = nil
         end
         
-        -- Always update content based on current afk status
+        GUI.PlayerDetailPopupAFKStatus = Geyser.Label:new({
+            name = statusLabelName,
+            x = statusX,
+            y = statusY,
+            width = statusSize,
+            height = statusSize,
+        }, GUI.PlayerDetailPopup)
+        
+        -- Set style and content based on AFK status
         if info.afk == 0 then
             -- Active - green filled circle
-            cecho("\n<green>DEBUG: Setting green circle for active player\n")
-            GUI.PlayerDetailPopupAFKStatus:echo("")  -- Clear any emoji content first
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
                 background-color: #00ff00;
                 border: 2px solid #333;
@@ -288,7 +272,6 @@ function GamePlayersInfo()
             ]])
         elseif info.afk == 1 then
             -- Away - crescent moon emoji
-            cecho("\n<orange>DEBUG: Setting crescent moon for away player\n")
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
                 background-color: transparent;
                 border: none;
@@ -297,11 +280,12 @@ function GamePlayersInfo()
             GUI.PlayerDetailPopupAFKStatus:echo([[<center>🌙</center>]])
         end
         
+        -- Prevent clicks from closing the popup
+        GUI.PlayerDetailPopupAFKStatus:setClickCallback(function() end)
+        
         GUI.PlayerDetailPopupAFKStatus:show()
         GUI.PlayerDetailPopupAFKStatus:raise()
-        cecho("\n<green>DEBUG: AFK status label shown and raised\n")
     elseif GUI.PlayerDetailPopupAFKStatus then
-        cecho("\n<red>DEBUG: Hiding AFK status label (info.afk is nil)\n")
         GUI.PlayerDetailPopupAFKStatus:hide()
     end
 end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -58,23 +58,14 @@ function GamePlayersInfo()
         )
     })
     
-    -- Alignment row (with optional OPK tag)
+    -- Alignment row
     if info.alignment then
-        local opkTag = ""
-        if info.opt_in_pk and info.opt_in_pk == 1 then
-            opkTag = string.format(
-                [[ <a href="send:pkinfo %s"><span style="background-color: red; color: white; padding: 1px 4px; font-weight: bold; border-radius: 2px;">OPK</span></a>]],
-                info.name:lower()
-            )
-        end
         table.insert(rows, {
             height = infoLineHeight,
             content = string.format(
-                [[<center><font size="3" color="gray">%s</font>%s</center>]],
-                firstToUpper(info.alignment),
-                opkTag
-            ),
-            linkStyle = info.opt_in_pk == 1 and {"white", "white", false} or nil
+                [[<center><font size="3" color="gray">%s</font></center>]],
+                firstToUpper(info.alignment)
+            )
         })
     end
     
@@ -288,5 +279,53 @@ function GamePlayersInfo()
         GUI.PlayerDetailPopupAFKStatus:raise()
     elseif GUI.PlayerDetailPopupAFKStatus then
         GUI.PlayerDetailPopupAFKStatus:hide()
+    end
+    
+    -- Create/update OPK indicator overlay to the right of avatar
+    if info.opt_in_pk == 1 then
+        local opkLabelName = "GUI.PlayerDetailPopupOPK"
+        
+        -- Calculate position (right of avatar, halfway to border)
+        local popupWidth = GUI.PlayerDetailPopup:get_width()
+        local avatarRightEdge = (popupWidth / 2) + 32  -- Center + half avatar width
+        local rightMargin = 10  -- Border padding
+        local availableSpace = popupWidth - avatarRightEdge - rightMargin
+        local opkWidth = 32
+        local opkHeight = 18
+        local opkX = avatarRightEdge + (availableSpace / 2) - (opkWidth / 2)  -- Centered in available space
+        local opkY = padding + 32 - (opkHeight / 2)  -- Vertically centered on avatar
+        
+        -- Always recreate the label to ensure it displays properly
+        if GUI.PlayerDetailPopupOPK then
+            GUI.PlayerDetailPopupOPK:hide()
+            GUI.PlayerDetailPopupOPK = nil
+        end
+        
+        GUI.PlayerDetailPopupOPK = Geyser.Label:new({
+            name = opkLabelName,
+            x = opkX,
+            y = opkY,
+            width = opkWidth,
+            height = opkHeight,
+        }, GUI.PlayerDetailPopup)
+        
+        GUI.PlayerDetailPopupOPK:setStyleSheet([[
+            background-color: #cc0000;
+            border: 1px solid #880000;
+            border-radius: 3px;
+        ]])
+        
+        GUI.PlayerDetailPopupOPK:echo(string.format(
+            [[<center><a href="send:pkinfo %s"><font size="2" color="white"><b>OPK</b></font></a></center>]],
+            info.name:lower()
+        ))
+        
+        -- Prevent clicks from closing the popup (but allow link clicks)
+        GUI.PlayerDetailPopupOPK:setClickCallback(function() end)
+        
+        GUI.PlayerDetailPopupOPK:show()
+        GUI.PlayerDetailPopupOPK:raise()
+    elseif GUI.PlayerDetailPopupOPK then
+        GUI.PlayerDetailPopupOPK:hide()
     end
 end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -242,23 +242,28 @@ function GamePlayersInfo()
         local statusLabelName = "GUI.PlayerDetailPopupAFKStatus"
         
         -- Calculate position (top-right corner of avatar)
-        -- Avatar is centered in popup, 64px wide, popup is likely ~200px wide
-        local avatarCenterX = "50%"
-        local statusX = "50%"  -- Center of popup
-        local statusXOffset = 22  -- Half avatar width (32px) minus half status size (10px)
+        -- Get popup dimensions to calculate proper positioning
+        local popupWidth = GUI.PlayerDetailPopup:get_width()
+        local popupHeight = GUI.PlayerDetailPopup:get_height()
+        
+        -- Avatar is 64px centered, status indicator is 20px
+        -- Position at top-right corner of avatar
+        local avatarHalfWidth = 32  -- 64px / 2
+        local statusSize = 20
+        local statusX = (popupWidth / 2) + avatarHalfWidth - statusSize
         local statusY = padding + 2  -- Just inside the avatar top edge
         
         if not GUI.PlayerDetailPopupAFKStatus then
             GUI.PlayerDetailPopupAFKStatus = Geyser.Label:new({
                 name = statusLabelName,
                 x = statusX,
-                y = statusY .. "px",
-                width = "20px",
-                height = "20px",
+                y = statusY,
+                width = statusSize,
+                height = statusSize,
             }, GUI.PlayerDetailPopup)
         else
-            GUI.PlayerDetailPopupAFKStatus:move(statusX, statusY .. "px")
-            GUI.PlayerDetailPopupAFKStatus:resize("20px", "20px")
+            GUI.PlayerDetailPopupAFKStatus:move(statusX, statusY)
+            GUI.PlayerDetailPopupAFKStatus:resize(statusSize, statusSize)
         end
         
         if info.afk == 0 then
@@ -268,6 +273,7 @@ function GamePlayersInfo()
                 border: 2px solid #333;
                 border-radius: 10px;
             ]])
+            GUI.PlayerDetailPopupAFKStatus:echo("")  -- Clear any previous content
         elseif info.afk == 1 then
             -- Away - crescent moon emoji
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -266,14 +266,15 @@ function GamePlayersInfo()
             GUI.PlayerDetailPopupAFKStatus:resize(statusSize, statusSize)
         end
         
+        -- Always update content based on current afk status
         if info.afk == 0 then
             -- Active - green filled circle
+            GUI.PlayerDetailPopupAFKStatus:echo("")  -- Clear any emoji content first
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
                 background-color: #00ff00;
                 border: 2px solid #333;
                 border-radius: 10px;
             ]])
-            GUI.PlayerDetailPopupAFKStatus:echo("")  -- Clear any previous content
         elseif info.afk == 1 then
             -- Away - crescent moon emoji
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -316,7 +316,7 @@ function GamePlayersInfo()
         ]])
         
         GUI.PlayerDetailPopupOPK:echo(string.format(
-            [[<center><a href="send:pkinfo %s"><font size="2" color="white"><b>OPK</b></font></a></center>]],
+            [[<center> <a href="send:pkinfo %s"><font size="2" color="white"><b>OPK</b></font></a> </center>]],
             info.name:lower()
         ))
         

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -29,12 +29,24 @@ function GamePlayersInfo()
     -- Build list of content rows to determine height
     local rows = {}
     
-    -- Avatar row
+    -- Avatar row with AFK status indicator
+    local statusIndicator = ""
+    if info.afk then
+        if info.afk == 0 then
+            -- Active - green filled circle
+            statusIndicator = [[<div style="position: absolute; top: 2px; right: 2px; width: 16px; height: 16px; background-color: #00ff00; border-radius: 50%; border: 2px solid #333;"></div>]]
+        elseif info.afk == 1 then
+            -- Away - yellow/orange crescent
+            statusIndicator = [[<div style="position: absolute; top: 2px; right: 2px; font-size: 16px; text-shadow: 0 0 3px #333;">🌙</div>]]
+        end
+    end
+    
     table.insert(rows, {
         height = avatarHeight,
         content = string.format(
-            [[<center><img src="%s" width="64" height="64"></center>]],
-            getGuildImagePath(info.guild, info.gender)
+            [[<center><div style="position: relative; display: inline-block;"><img src="%s" width="64" height="64">%s</div></center>]],
+            getGuildImagePath(info.guild, info.gender),
+            statusIndicator
         )
     })
     
@@ -47,15 +59,25 @@ function GamePlayersInfo()
         )
     })
     
-    -- Race/Guild/Level row
+    -- Race/Guild/Level row with OPK tag
+    local opkTag = ""
+    if info.opt_in_pk and info.opt_in_pk == 1 then
+        opkTag = string.format(
+            [[ <a href="send:pkinfo %s"><span style="background-color: blue; color: yellow; padding: 1px 4px; font-weight: bold; border-radius: 2px;">OPK</span></a>]],
+            info.name:lower()
+        )
+    end
+    
     table.insert(rows, {
         height = infoLineHeight,
         content = string.format(
-            [[<center><font size="3" color="silver">%s %s - Level %d</font></center>]],
+            [[<center><font size="3" color="silver">%s %s - Level %d%s</font></center>]],
             firstToUpper(info.race),
             firstToUpper(info.guild),
-            info.level
-        )
+            info.level,
+            opkTag
+        ),
+        linkStyle = info.opt_in_pk == 1 and {"yellow", "yellow", false} or nil
     })
     
     -- Alignment row

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -58,26 +58,23 @@ function GamePlayersInfo()
         )
     })
     
-    -- Alignment row
+    -- Alignment row (with optional OPK tag)
     if info.alignment then
-        table.insert(rows, {
-            height = infoLineHeight,
-            content = string.format(
-                [[<center><font size="3" color="gray">%s</font></center>]],
-                firstToUpper(info.alignment)
-            )
-        })
-    end
-    
-    -- OPK (Opt-in Player Kill) tag row
-    if info.opt_in_pk and info.opt_in_pk == 1 then
-        table.insert(rows, {
-            height = infoLineHeight,
-            content = string.format(
-                [[<center> <a href="send:pkinfo %s"><span style="background-color: red; color: white; padding: 1px 4px; font-weight: bold; border-radius: 2px;">OPK</span></a></center>]],
+        local opkTag = ""
+        if info.opt_in_pk and info.opt_in_pk == 1 then
+            opkTag = string.format(
+                [[ <a href="send:pkinfo %s"><span style="background-color: red; color: white; padding: 1px 4px; font-weight: bold; border-radius: 2px;">OPK</span></a>]],
                 info.name:lower()
+            )
+        end
+        table.insert(rows, {
+            height = infoLineHeight,
+            content = string.format(
+                [[<center><font size="3" color="gray">%s</font>%s</center>]],
+                firstToUpper(info.alignment),
+                opkTag
             ),
-            linkStyle = {"white", "white", false}
+            linkStyle = info.opt_in_pk == 1 and {"white", "white", false} or nil
         })
     end
     
@@ -243,13 +240,13 @@ function GamePlayersInfo()
     if info.afk ~= nil then
         local statusLabelName = "GUI.PlayerDetailPopupAFKStatus"
         
-        -- Calculate position (bottom-right corner of avatar)
+        -- Calculate position (lower-right, outside avatar)
         local popupWidth = GUI.PlayerDetailPopup:get_width()
         local avatarHalfWidth = 32  -- 64px / 2
         local avatarSize = 64
         local statusSize = 20
-        local statusX = (popupWidth / 2) + avatarHalfWidth - statusSize
-        local statusY = padding + avatarSize - statusSize - 2  -- Position at bottom of avatar
+        local statusX = (popupWidth / 2) + avatarHalfWidth - 4  -- Slightly to the right of avatar
+        local statusY = padding + avatarSize - 8  -- Slightly below avatar bottom
         
         -- Always recreate the label to ensure it displays properly
         if GUI.PlayerDetailPopupAFKStatus then

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -239,6 +239,8 @@ function GamePlayersInfo()
     
     -- Create/update AFK status indicator overlay on avatar
     if info.afk ~= nil then
+        cecho(string.format("\n<green>DEBUG: Showing AFK indicator for %s, afk=%d\n", info.name, info.afk))
+        
         local statusLabelName = "GUI.PlayerDetailPopupAFKStatus"
         
         -- Calculate position (top-right corner of avatar)
@@ -254,6 +256,7 @@ function GamePlayersInfo()
         local statusY = padding + 2  -- Just inside the avatar top edge
         
         if not GUI.PlayerDetailPopupAFKStatus then
+            cecho("\n<yellow>DEBUG: Creating new AFK status label\n")
             GUI.PlayerDetailPopupAFKStatus = Geyser.Label:new({
                 name = statusLabelName,
                 x = statusX,
@@ -262,6 +265,7 @@ function GamePlayersInfo()
                 height = statusSize,
             }, GUI.PlayerDetailPopup)
         else
+            cecho("\n<cyan>DEBUG: Updating existing AFK status label\n")
             GUI.PlayerDetailPopupAFKStatus:move(statusX, statusY)
             GUI.PlayerDetailPopupAFKStatus:resize(statusSize, statusSize)
         end
@@ -269,6 +273,7 @@ function GamePlayersInfo()
         -- Always update content based on current afk status
         if info.afk == 0 then
             -- Active - green filled circle
+            cecho("\n<green>DEBUG: Setting green circle for active player\n")
             GUI.PlayerDetailPopupAFKStatus:echo("")  -- Clear any emoji content first
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
                 background-color: #00ff00;
@@ -277,6 +282,7 @@ function GamePlayersInfo()
             ]])
         elseif info.afk == 1 then
             -- Away - crescent moon emoji
+            cecho("\n<orange>DEBUG: Setting crescent moon for away player\n")
             GUI.PlayerDetailPopupAFKStatus:setStyleSheet([[
                 background-color: transparent;
                 border: none;
@@ -287,7 +293,9 @@ function GamePlayersInfo()
         
         GUI.PlayerDetailPopupAFKStatus:show()
         GUI.PlayerDetailPopupAFKStatus:raise()
+        cecho("\n<green>DEBUG: AFK status label shown and raised\n")
     elseif GUI.PlayerDetailPopupAFKStatus then
+        cecho("\n<red>DEBUG: Hiding AFK status label (info.afk is nil)\n")
         GUI.PlayerDetailPopupAFKStatus:hide()
     end
 end

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersList.lua
@@ -423,6 +423,9 @@ end
 
 -- Create the Game Players List using individual labels
 function GamePlayersList()
+    -- Close any existing popup to ensure clean state on reconnect
+    ClosePlayerDetailPopup()
+    
     local game_players_list = gmcp.Game and gmcp.Game.Players and gmcp.Game.Players.List or {}
     local yPos = 0
     local rowIndex = 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AFK status indicator now displays on player avatars
  * OPK (opt-in PvP) indicator added to player detail view

* **Improvements**
  * Enhanced server capability communication for supported packages
  * Improved player list state management with better popup cleanup

* **Other**
  * Version updated to 107

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->