### PR TITLE
Add top sailing rankings to player info popup

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "110",
+       "version": "111",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -155,6 +155,21 @@ function GamePlayersInfo()
         end
     end
     
+    -- Top sailing rows (one per route)
+    if info.top_sailing and next(info.top_sailing) then
+        for route, rank in pairs(info.top_sailing) do
+            local rankColor = rank == 1 and "gold" or "silver"
+            table.insert(rows, {
+                height = smallLineHeight,
+                content = string.format(
+                    [[<center><a href="send:shiptop player %s"><font size="2" color="%s">#%d ⛵ %s</font></a></center>]],
+                    info.name:lower(), rankColor, rank, route
+                ),
+                linkStyle = {rankColor, rankColor, false}
+            })
+        end
+    end
+    
     -- Calculate total height
     local totalHeight = padding
     for _, row in ipairs(rows) do


### PR DESCRIPTION
Display top_sailing data showing player's best sailing routes between destinations. Each route shows rank (#1 gold, others silver) with a sailing emoji and clickable link to 'shiptop player <name>'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added top sailing rankings display to the GamePlayersInfo panel, showing player rank, route, and color-coded rank indicators (gold for 1st place, silver for others).

* **Chores**
  * Version bump to 111.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->