### PR TITLE
Change sailing link to use shiptop route command

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "111",
+       "version": "112",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -159,11 +159,13 @@ function GamePlayersInfo()
     if info.top_sailing and next(info.top_sailing) then
         for route, rank in pairs(info.top_sailing) do
             local rankColor = rank == 1 and "gold" or "silver"
+            -- Extract port names from route (e.g., "Tristeza • Asahi" -> "Tristeza", "Asahi")
+            local port1, port2 = route:match("^%s*(.-)%s*•%s*(.-)%s*$")
             table.insert(rows, {
                 height = smallLineHeight,
                 content = string.format(
-                    [[<center><a href="send:shiptop player %s"><font size="2" color="%s">#%d ⛵ %s</font></a></center>]],
-                    info.name:lower(), rankColor, rank, route
+                    [[<center><a href="send:shiptop route %s %s"><font size="2" color="%s">#%d ⛵ %s</font></a></center>]],
+                    port1, port2, rankColor, rank, route
                 ),
                 linkStyle = {rankColor, rankColor, false}
             })


### PR DESCRIPTION
Parse route string to extract port names and send 'shiptop route <port1> <port2>' instead of 'shiptop player <name>'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Top Sailing section now correctly parses route information and generates navigation links with appropriate parameters.

* **Chores**
  * Version updated to 112.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->