### PR TITLE
Fix shiptop route command to use short port fragments

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "113",
+       "version": "114",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -161,11 +161,14 @@ function GamePlayersInfo()
             local rankColor = rank == 1 and "gold" or "silver"
             -- Extract port names from route (e.g., "Tristeza • Asahi" -> "Tristeza", "Asahi")
             local port1, port2 = route:match("^%s*(.-)%s*•%s*(.-)%s*$")
+            -- Use last word of each port name (lowercased) for server's sscanf parsing
+            local port1Short = port1:match("(%S+)$"):lower()
+            local port2Short = port2:match("(%S+)$"):lower()
             table.insert(rows, {
                 height = smallLineHeight,
                 content = string.format(
                     [[<center><a href="send:shiptop route %s %s"><font size="2" color="%s">#%d ⛵ %s</font></a></center>]],
-                    port1, port2, rankColor, rank, route
+                    port1Short, port2Short, rankColor, rank, route
                 ),
                 linkStyle = {rankColor, rankColor, false}
             })


### PR DESCRIPTION
The server's sscanf parsing only captures single words, so multi-word port names like 'Port of Eloria' broke the command. Now extracts and sends just the last word (lowercased) of each port name, which works with the server's fuzzy matching.

Examples:
- 'Port of Eloria' → 'eloria'
- 'Port of Westhorn' → 'westhorn'
- 'Isle of Laite' → 'laite'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Player information popup now displays port names in shortened format within sailing route information.

* **Chores**
  * Updated version to 114.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->