### PR TITLE
Refine More Prompt regex patterns and hyperlink handling

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "120",
+       "version": "121",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/triggers/More/triggers.json
+++ b/src/triggers/More/triggers.json
@@ -13,7 +13,7 @@
               "highlightBG": "#ffff00",
               "patterns": [
                      {
-                            "pattern": "(?:^|\\x1b[^m]*m|\\x1b\\]8;[^\\x07\\x1b]*(?:\\x07|\\x1b\\\\))More(?:\\x1b\\]8;;(?:\\x07|\\x1b\\\\))? \\((?:\\d+%|Line \\d+/\\d+|\\d+/\\?)\\) Enter=next q=quit \\?=help",
+                            "pattern": "\\(\\d+%\\) Enter=next q=quit \\?=help",
                             "type": "perl regex"
                      }
               ],

--- a/src/triggers/More/triggers.json
+++ b/src/triggers/More/triggers.json
@@ -13,7 +13,7 @@
               "highlightBG": "#ffff00",
               "patterns": [
                      {
-                            "pattern": "^(?:\\e\\]8;[^\\e]*\\e\\\\)?More(?:\\e\\]8;;\\e\\\\)? \\((?:\\d+%|Line \\d+/\\d+|\\d+/\\?)\\) Enter=next q=quit \\?=help$",
+                            "pattern": "^More \\((?:\\d+%|Line \\d+/\\d+|\\d+/\\?)\\) Enter=next q=quit \\?=help",
                             "type": "perl regex"
                      }
               ],

--- a/src/triggers/More/triggers.json
+++ b/src/triggers/More/triggers.json
@@ -13,7 +13,7 @@
               "highlightBG": "#ffff00",
               "patterns": [
                      {
-                            "pattern": "^More \\((?:\\d+%|Line \\d+/\\d+|\\d+/\\?)\\) Enter=next q=quit \\?=help",
+                            "pattern": "(?:^|\\x1b[^m]*m|\\x1b\\]8;[^\\x07\\x1b]*(?:\\x07|\\x1b\\\\))More(?:\\x1b\\]8;;(?:\\x07|\\x1b\\\\))? \\((?:\\d+%|Line \\d+/\\d+|\\d+/\\?)\\) Enter=next q=quit \\?=help",
                             "type": "perl regex"
                      }
               ],

--- a/src/triggers/More/triggers.json
+++ b/src/triggers/More/triggers.json
@@ -13,8 +13,8 @@
               "highlightBG": "#ffff00",
               "patterns": [
                      {
-                            "pattern": "^--More-- \\[",
-                            "type": "regex"
+                            "pattern": "^(?:\\e\\]8;[^\\e]*\\e\\\\)?More(?:\\e\\]8;;\\e\\\\)? \\((?:\\d+%|Line \\d+/\\d+|\\d+/\\?)\\) Enter=next q=quit \\?=help$",
+                            "type": "perl regex"
                      }
               ],
               "script": ""

--- a/src/triggers/More/triggers.json
+++ b/src/triggers/More/triggers.json
@@ -13,8 +13,8 @@
               "highlightBG": "#ffff00",
               "patterns": [
                      {
-                            "pattern": "\\(\\d+%\\) Enter=next q=quit \\?=help",
-                            "type": "perl regex"
+                            "pattern": "^More \\(\\d+%\\) Enter=next q=quit \\?=help",
+                            "type": "regex"
                      }
               ],
               "script": ""


### PR DESCRIPTION
This pull request includes a version bump for the StickMUDMudletGUI package and an update to a trigger pattern in the `triggers.json` configuration file.

Versioning:

* Incremented the `version` field from `120` to `121` in the `mfile` to mark a new release.

Trigger pattern update:

* Updated the "More" message trigger pattern in `src/triggers/More/triggers.json` to match the new message format: changed from matching `"^--More-- \["` to `"^More \(\d+%\) Enter=next q=quit \?=help"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated "More Prompt" trigger pattern recognition to correctly identify pagination continuation prompts during extended output display, improving system responsiveness to user navigation requests for large result sets.

* **Chores**
  * Version updated to 121.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->