### PR TITLE
Add ability-cooldown gauges for Char.Cooldowns GMCP package

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "123",
+       "version": "124",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "122",
+       "version": "123",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/AbilitiesButtons/CharCooldownsAdd.lua
+++ b/src/scripts/GMCP/AbilitiesButtons/CharCooldownsAdd.lua
@@ -1,0 +1,22 @@
+function CharCooldownsAdd()
+    -- Check if GMCP Char.Cooldowns.Add data is available
+    if not gmcp or not gmcp.Char or not gmcp.Char.Cooldowns or not gmcp.Char.Cooldowns.Add then
+        return
+    end
+    
+    local data = gmcp.Char.Cooldowns.Add
+    
+    -- An empty Add (no name) is the reset signal that precedes a List reply:
+    -- clear all tracked cooldowns so the repopulate has no stale/duplicate rows.
+    if not data.name then
+        if ClearAllCooldowns then
+            ClearAllCooldowns()
+        end
+        return
+    end
+    
+    -- Populated payload: add or refresh the cooldown row
+    if data.cooldown and AddCooldown then
+        AddCooldown(data.name, data.cooldown)
+    end
+end

--- a/src/scripts/GMCP/AbilitiesButtons/scripts.json
+++ b/src/scripts/GMCP/AbilitiesButtons/scripts.json
@@ -25,5 +25,14 @@
                      "gmcp.Char.Abilities.Remove"
               ],
               "script": ""
+       },
+       {
+              "isActive": "yes",
+              "isFolder": "no",
+              "name": "CharCooldownsAdd",
+              "eventHandlerList": [
+                     "gmcp.Char.Cooldowns.Add"
+              ],
+              "script": ""
        }
 ]

--- a/src/scripts/GMCP/CoreGoodbye.lua
+++ b/src/scripts/GMCP/CoreGoodbye.lua
@@ -29,4 +29,9 @@ function CoreGoodbye()
   if ClearAllAbilities then
     ClearAllAbilities()
   end
+
+  -- Clean up cooldowns (kills all cooldown tempTimers and clears state)
+  if ClearAllCooldowns then
+    ClearAllCooldowns()
+  end
 end

--- a/src/scripts/GMCP/Initialize.lua
+++ b/src/scripts/GMCP/Initialize.lua
@@ -37,6 +37,7 @@ local packages = {
     "Char.Status 1",          -- CharStatus.lua
     "Char.Items 1",           -- Inventory and Room item handlers
     "Char.Abilities 1",       -- AbilitiesButtons handlers
+    "Char.Cooldowns 1",       -- AbilitiesButtons/CharCooldownsAdd.lua
     "Char.Help 1",            -- HelpContainer/CharHelpList.lua
     "Char.Guild.Help 1",      -- AbilitiesConsole/CharGuildHelpList.lua
     "Char.Training 1",        -- TrainingScrollBox handlers
@@ -177,6 +178,9 @@ end
 sendGMCP("Char.Vitals")
 sendGMCP("Char.Status")
 sendGMCP("Game.Players.List")
+
+-- Repopulate in-progress ability cooldowns after a reconnect/reload
+sendGMCP("Char.Cooldowns.List")
 
 -- Start periodic checks with backoff
 ScheduleGMCPCheck("Vitals", CheckVitalsAndRefresh)

--- a/src/scripts/GMCP/Initialize.lua
+++ b/src/scripts/GMCP/Initialize.lua
@@ -65,7 +65,8 @@ sendGMCP("Core.Supports.Add " .. yajl.to_string(packages))
 GUI.GMCPRetryState = GUI.GMCPRetryState or {
     Vitals = { count = 0, interval = 10 },
     Status = { count = 0, interval = 10 },
-    Players = { count = 0, interval = 10 }
+    Players = { count = 0, interval = 10 },
+    Cooldowns = { count = 0, interval = 10 }
 }
 GUI.GMCPMaxRetries = 5  -- Stop after this many attempts
 GUI.GMCPBaseInterval = 10  -- Base interval in seconds
@@ -146,6 +147,29 @@ function CheckPlayersAndRefresh()
     return false  -- Keep trying
 end
 
+-- Function to check and refresh Char.Cooldowns.List
+-- Returns true if cooldowns are tracked or max retries reached (should stop checking)
+-- Note: an empty cooldown list is a valid steady state (player may have no active
+-- cooldowns), so we rely on the capped retry count to stop polling rather than
+-- treating "empty" as a permanent failure.
+function CheckCooldownsAndRefresh()
+    -- Check if any cooldowns are being tracked
+    if GUI and GUI.ActiveCooldowns and next(GUI.ActiveCooldowns) ~= nil then
+        ResetGMCPRetryState("Cooldowns")
+        return true  -- Data received, stop checking
+    end
+    
+    if not IsGMCPConnected() then return false end  -- Keep trying
+    
+    local state = GUI.GMCPRetryState.Cooldowns
+    if state.count >= GUI.GMCPMaxRetries then return true end  -- Max retries, stop
+    
+    state.count = state.count + 1
+    sendGMCP("Char.Cooldowns.List")
+    state.interval = math.min(state.interval * 2, 300)
+    return false  -- Keep trying
+end
+
 -- Kill existing timers
 for name, timerId in pairs(GUI.GMCPTimers) do
     if timerId then killTimer(timerId) end
@@ -186,3 +210,4 @@ sendGMCP("Char.Cooldowns.List")
 ScheduleGMCPCheck("Vitals", CheckVitalsAndRefresh)
 ScheduleGMCPCheck("Status", CheckStatusAndRefresh)
 ScheduleGMCPCheck("Players", CheckPlayersAndRefresh)
+ScheduleGMCPCheck("Cooldowns", CheckCooldownsAndRefresh)

--- a/src/scripts/GUI/Create_Middle.lua
+++ b/src/scripts/GUI/Create_Middle.lua
@@ -243,6 +243,22 @@ GUI.AbilityTimers = {}
 -- Clear active abilities on reload (server will resend if still active)
 GUI.ActiveAbilities = {}
 
+-- Storage for active cooldowns (recharge/reusage timers)
+-- Rendered into the same GUI.AbilitiesListContainer stack as buffs, but kept in
+-- parallel state so an active buff and its cooldown never clobber each other.
+-- Keyed by cooldown id (a stable numeric hash from the server).
+GUI.ActiveCooldowns = GUI.ActiveCooldowns or {}
+GUI.CooldownTimers = GUI.CooldownTimers or {}
+
+-- Kill any existing cooldown timers on reload (will be recreated via List)
+for id, timerId in pairs(GUI.CooldownTimers) do
+    killTimer(timerId)
+end
+GUI.CooldownTimers = {}
+
+-- Clear active cooldowns on reload (server will resend via Char.Cooldowns.List)
+GUI.ActiveCooldowns = {}
+
 -- CSS styles for ability gauges (inspired by footer)
 GUI.AbilityGaugeBackCSS = CSSMan.new([[
     background-color: #1a1a1a;
@@ -260,7 +276,8 @@ GUI.AbilityGaugeFrontCSS = CSSMan.new([[
 -- Color schemes for different ability states
 GUI.AbilityColors = {
     warning = {front = "#f39c12", back = "#4d3205"},    -- Orange for warning
-    expiring = {front = "#e74c3c", back = "#4a1a15"}    -- Red for expiring soon
+    expiring = {front = "#e74c3c", back = "#4a1a15"},   -- Red for expiring soon
+    cooldown = {front = "#5a7a99", back = "#1e2b36"}    -- Muted steel-blue for recharging cooldowns
 }
 
 -- Color palette for active abilities (good contrast with white text)
@@ -322,7 +339,11 @@ function RefreshAbilitiesDisplay()
     -- Get sorted list of abilities (sort by remaining time: longest at top, shortest at bottom)
     local sortedAbilities = {}
     for id, ability in pairs(GUI.ActiveAbilities) do
-        table.insert(sortedAbilities, {id = id, name = ability.name, data = ability})
+        table.insert(sortedAbilities, {id = id, name = ability.name, data = ability, kind = "buff"})
+    end
+    -- Cooldowns render in the same stack as buffs but are tracked separately
+    for id, cooldown in pairs(GUI.ActiveCooldowns) do
+        table.insert(sortedAbilities, {id = id, name = cooldown.name, data = cooldown, kind = "cooldown"})
     end
     table.sort(sortedAbilities, function(a, b)
         -- Get remaining times (treat nil or 0 as infinite/permanent)
@@ -356,23 +377,44 @@ function RefreshAbilitiesDisplay()
         -- Debug: echo("[RefreshDisplay] Processing ability " .. i .. ": " .. abilityInfo.name .. "\n")
         local ability = abilityInfo.data
         local name = abilityInfo.name
-        local colors = getAbilityColor(ability.remaining, ability.warn, name)
         
         -- Calculate y position from bottom
         -- First ability (i=1) at top of stack, last ability at very bottom
         local yPos = "-" .. ((numAbilities - i + 1) * rowHeight) .. "px"
         
-        -- Calculate gauge value (100% if no expiry, percentage if expiring)
-        local gaugeValue = 100
-        if ability.expires and ability.expires > 0 and ability.remaining then
-            gaugeValue = math.max(0, math.min(100, (ability.remaining / ability.expires) * 100))
-        end
+        local colors
+        local gaugeValue
+        local labelText
         
-        -- Format the label text (just the ability name, time shown via gauge fill)
-        local labelText = string.format(
-            [[<center><font size="3" color="white"><b>%s</b></font></center>]],
-            firstToUpper(name)
-        )
+        if abilityInfo.kind == "cooldown" then
+            -- Cooldowns use a distinct color and fill LEFT-TO-RIGHT as they elapse:
+            -- the gauge value is the ELAPSED fraction, not the remaining fraction.
+            colors = GUI.AbilityColors.cooldown
+            local duration = ability.duration or 0
+            local remaining = ability.remaining or 0
+            if duration > 0 then
+                gaugeValue = math.max(0, math.min(100, ((duration - remaining) / duration) * 100))
+            else
+                gaugeValue = 100
+            end
+            -- Show the ability name plus the countdown to recharge completion
+            labelText = string.format(
+                [[<center><font size="3" color="white"><b>%s</b> %s</font></center>]],
+                firstToUpper(name), formatTimeRemaining(remaining)
+            )
+        else
+            -- Buffs keep the existing depleting behavior (fill = remaining fraction)
+            colors = getAbilityColor(ability.remaining, ability.warn, name)
+            gaugeValue = 100
+            if ability.expires and ability.expires > 0 and ability.remaining then
+                gaugeValue = math.max(0, math.min(100, (ability.remaining / ability.expires) * 100))
+            end
+            -- Format the label text (just the ability name, time shown via gauge fill)
+            labelText = string.format(
+                [[<center><font size="3" color="white"><b>%s</b></font></center>]],
+                firstToUpper(name)
+            )
+        end
         
         local existingRow = GUI.AbilityRows[i]
         -- Debug: echo("[RefreshDisplay] Checking existing row: " .. tostring(existingRow ~= nil) .. ", gauge: " .. tostring(existingRow and existingRow.gauge ~= nil) .. "\n")
@@ -398,6 +440,7 @@ function RefreshAbilitiesDisplay()
             
             -- Update click callback with current ability name
             -- Note: Gauge doesn't have setClickCallback, use the front label
+            -- Cooldown rows stay click-to-send too, so the player can queue the recast.
             local abilityName = name
             gauge.front:setClickCallback(function()
                 send(abilityName)
@@ -606,6 +649,115 @@ function ClearAllAbilities()
             end
         end
     end
+end
+
+-- ============================================
+-- COOLDOWNS (reusage / recharge timers)
+-- ============================================
+-- Cooldowns are distinct from buff monitors: they represent the recharge period
+-- before an ability can be used again. They share the abilities panel/stack but
+-- use a distinct color, fill left-to-right as they elapse, and self-remove when
+-- the local countdown reaches 0 (the server sends no Remove message).
+
+-- Function to add/refresh a cooldown (keyed by cooldown id)
+function AddCooldown(name, cooldownData)
+    local id = cooldownData and cooldownData.id or nil
+    if not id then
+        -- No cooldown id provided, cannot track this cooldown
+        return
+    end
+    
+    local duration = tonumber(cooldownData.duration) or 0
+    local remaining = tonumber(cooldownData.remaining) or duration
+    
+    -- A re-cast/update with the same id replaces the existing entry
+    GUI.ActiveCooldowns[id] = {
+        name = name,
+        duration = duration,
+        remaining = remaining,
+        kind = "cooldown",
+        startTime = os.time()
+    }
+    
+    -- (Re)start the countdown timer for this cooldown id
+    if GUI.CooldownTimers[id] then
+        killTimer(GUI.CooldownTimers[id])
+        GUI.CooldownTimers[id] = nil
+    end
+    
+    if remaining and remaining > 0 then
+        GUI.CooldownTimers[id] = tempTimer(1, function()
+            UpdateCooldownTimer(id)
+        end, true)  -- repeating timer
+    else
+        -- Already complete, nothing to show
+        GUI.ActiveCooldowns[id] = nil
+    end
+    
+    RefreshAbilitiesDisplay()
+end
+
+-- Function to tick a cooldown countdown (by cooldown id)
+-- Self-removes the cooldown when it reaches 0 since there is no server Remove.
+function UpdateCooldownTimer(cooldownId)
+    local cooldown = GUI.ActiveCooldowns[cooldownId]
+    if not cooldown then
+        -- Cooldown was cleared, kill timer
+        if GUI.CooldownTimers[cooldownId] then
+            killTimer(GUI.CooldownTimers[cooldownId])
+            GUI.CooldownTimers[cooldownId] = nil
+        end
+        return
+    end
+    
+    if cooldown.remaining and cooldown.remaining > 0 then
+        cooldown.remaining = cooldown.remaining - 1
+    end
+    
+    if cooldown.remaining and cooldown.remaining <= 0 then
+        -- Cooldown complete: kill timer, remove entry, and refresh so the row disappears
+        if GUI.CooldownTimers[cooldownId] then
+            killTimer(GUI.CooldownTimers[cooldownId])
+            GUI.CooldownTimers[cooldownId] = nil
+        end
+        GUI.ActiveCooldowns[cooldownId] = nil
+        -- Hide all gauges first; RefreshAbilitiesDisplay re-shows the remaining rows
+        for i, row in pairs(GUI.AbilityRows) do
+            if row and row.gauge then
+                row.gauge:hide()
+            end
+        end
+    end
+    
+    RefreshAbilitiesDisplay()
+end
+
+-- Function to clear all cooldowns (reset signal / disconnect cleanup)
+-- Modeled on ClearAllAbilities, but only touches cooldown state. Buff rows are
+-- redrawn by the final RefreshAbilitiesDisplay call.
+function ClearAllCooldowns()
+    -- Kill all cooldown timers
+    if GUI.CooldownTimers then
+        for id, timerId in pairs(GUI.CooldownTimers) do
+            killTimer(timerId)
+        end
+    end
+    GUI.CooldownTimers = {}
+    
+    -- Clear cooldown state
+    GUI.ActiveCooldowns = {}
+    
+    -- Hide all gauges in the shared row pool; RefreshAbilitiesDisplay re-shows
+    -- any remaining buff rows.
+    if GUI.AbilityRows then
+        for i, row in pairs(GUI.AbilityRows) do
+            if row and row.gauge and row.gauge.hide then
+                row.gauge:hide()
+            end
+        end
+    end
+    
+    RefreshAbilitiesDisplay()
 end
 
 -- Retry state for abilities refresh (preserved across reloads)


### PR DESCRIPTION
Render the server's new Char.Cooldowns package as left-to-right recharging gauges in the abilities panel, visually distinct from active buff monitors.

- New thin handler CharCooldownsAdd delegates to AddCooldown / ClearAllCooldowns (empty Add = reset signal before a List reply)
- Create_Middle: parallel cooldown state, kind-aware render with a muted steel-blue color and elapsed (left-to-right) fill, self-removal when the client countdown hits 0 (no server Remove message)
- Declare Char.Cooldowns 1 and request Char.Cooldowns.List on startup
- Clear cooldowns and kill cooldown timers on disconnect
- Bump package version to 123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ability cooldowns are now tracked and displayed in the abilities panel with visual progress indicators
  * Cooldown timers update in real-time to show remaining recast time
  * Cooldowns persist and repopulate correctly after reconnection or reload

* **Chores**
  * Version bump to 123

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StickMUD/StickMUDMudletGUI/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->