### PR TITLE
Add Char.Resistances handlers and fix event session cleanup

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "124",
+       "version": "125",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/EventsScrollBox/GameEventsEnd.lua
+++ b/src/scripts/GMCP/EventsScrollBox/GameEventsEnd.lua
@@ -16,8 +16,14 @@ function GameEventsEnd(event, gmcp_data)
     end
     
     -- Clear session data for this event
-    if eventsSessionData and eventsSessionData.event_id == data.id then
-        eventsSessionData = {}
+    -- eventsSessionData is an array of session objects, so iterate and remove
+    -- the one whose event_id matches the ended event
+    if eventsSessionData and type(eventsSessionData) == "table" then
+        for i = #eventsSessionData, 1, -1 do
+            if eventsSessionData[i].event_id == data.id then
+                table.remove(eventsSessionData, i)
+            end
+        end
     end
     
     -- Only rebuild the display if EventsScrollBox is currently selected

--- a/src/scripts/GMCP/Initialize.lua
+++ b/src/scripts/GMCP/Initialize.lua
@@ -42,6 +42,7 @@ local packages = {
     "Char.Guild.Help 1",      -- AbilitiesConsole/CharGuildHelpList.lua
     "Char.Training 1",        -- TrainingScrollBox handlers
     "Char.Events 1",          -- EventsScrollBox/CharEventsList.lua
+    "Char.Resistances 1",     -- Resistances handlers
 
     -- Room
     "Room 1",                 -- RoomInfo.lua, Room.Players handlers

--- a/src/scripts/GMCP/Resistances/CharResistancesAdd.lua
+++ b/src/scripts/GMCP/Resistances/CharResistancesAdd.lua
@@ -1,0 +1,17 @@
+-- Handler for Char.Resistances.Add GMCP package
+-- Adds (or updates) a single resistance in the character's resistance table
+
+function CharResistancesAdd()
+    -- Check if GMCP Char.Resistances.Add data is available
+    if not gmcp or not gmcp.Char or not gmcp.Char.Resistances or not gmcp.Char.Resistances.Add then
+        return
+    end
+
+    local data = gmcp.Char.Resistances.Add
+    if type(data) ~= "table" or not data.name then
+        return
+    end
+
+    charResistances = charResistances or {}
+    charResistances[data.name] = { name = data.name, desc = data.desc }
+end

--- a/src/scripts/GMCP/Resistances/CharResistancesList.lua
+++ b/src/scripts/GMCP/Resistances/CharResistancesList.lua
@@ -1,0 +1,26 @@
+-- Handler for Char.Resistances.List GMCP package
+-- Replaces the full set of the character's known resistances
+
+-- Global table of the character's resistances, keyed by resistance name.
+-- Each entry is { name = <string>, desc = <string> }
+charResistances = charResistances or {}
+
+function CharResistancesList()
+    -- Check if GMCP Char.Resistances.List data is available
+    if not gmcp or not gmcp.Char or not gmcp.Char.Resistances or not gmcp.Char.Resistances.List then
+        return
+    end
+
+    local list = gmcp.Char.Resistances.List
+    if type(list) ~= "table" then
+        return
+    end
+
+    -- Rebuild the table from scratch since List is the authoritative set
+    charResistances = {}
+    for _, resist in ipairs(list) do
+        if resist.name then
+            charResistances[resist.name] = { name = resist.name, desc = resist.desc }
+        end
+    end
+end

--- a/src/scripts/GMCP/Resistances/CharResistancesRemove.lua
+++ b/src/scripts/GMCP/Resistances/CharResistancesRemove.lua
@@ -1,0 +1,26 @@
+-- Handler for Char.Resistances.Remove GMCP package
+-- Removes a single resistance from the character's resistance table
+
+function CharResistancesRemove()
+    -- Check if GMCP Char.Resistances.Remove data is available
+    if not gmcp or not gmcp.Char or not gmcp.Char.Resistances or not gmcp.Char.Resistances.Remove then
+        return
+    end
+
+    local data = gmcp.Char.Resistances.Remove
+
+    -- Remove may arrive as a table ({ name = ... }) or a bare name string
+    local name
+    if type(data) == "table" then
+        name = data.name
+    elseif type(data) == "string" then
+        name = data
+    end
+
+    if not name then
+        return
+    end
+
+    charResistances = charResistances or {}
+    charResistances[name] = nil
+end

--- a/src/scripts/GMCP/Resistances/scripts.json
+++ b/src/scripts/GMCP/Resistances/scripts.json
@@ -1,0 +1,29 @@
+[
+       {
+              "isActive": "yes",
+              "isFolder": "no",
+              "name": "CharResistancesList",
+              "eventHandlerList": [
+                     "gmcp.Char.Resistances.List"
+              ],
+              "script": ""
+       },
+       {
+              "isActive": "yes",
+              "isFolder": "no",
+              "name": "CharResistancesAdd",
+              "eventHandlerList": [
+                     "gmcp.Char.Resistances.Add"
+              ],
+              "script": ""
+       },
+       {
+              "isActive": "yes",
+              "isFolder": "no",
+              "name": "CharResistancesRemove",
+              "eventHandlerList": [
+                     "gmcp.Char.Resistances.Remove"
+              ],
+              "script": ""
+       }
+]

--- a/src/scripts/GMCP/scripts.json
+++ b/src/scripts/GMCP/scripts.json
@@ -106,6 +106,12 @@
        },
        {
               "isActive": "yes",
+              "isFolder": "yes",
+              "name": "Resistances",
+              "script": ""
+       },
+       {
+              "isActive": "yes",
               "isFolder": "no",
               "name": "Initialize",
               "script": ""


### PR DESCRIPTION
This pull request adds support for tracking character resistances via GMCP in the StickMUD Mudlet GUI. It introduces new handlers for the `Char.Resistances` GMCP packages, updates the initialization to include these packages, and organizes the new scripts in their own folder. Additionally, it fixes a bug in event session data cleanup and bumps the package version.

**GMCP Resistances Support:**

* Added handlers for `Char.Resistances.List`, `Char.Resistances.Add`, and `Char.Resistances.Remove` GMCP packages to maintain a global `charResistances` table, allowing the GUI to track and update character resistances in real time.
* Registered the new resistances scripts and their GMCP event bindings in `src/scripts/GMCP/Resistances/scripts.json`.
* Updated `src/scripts/GMCP/scripts.json` to add a new "Resistances" folder for organization.
* Included `"Char.Resistances 1"` in the list of initialized GMCP packages in `src/scripts/GMCP/Initialize.lua`.

**Bug Fix:**

* Fixed cleanup logic in `GameEventsEnd` to correctly remove only the ended event from `eventsSessionData` when it is an array, preventing potential data leakage between events.

**Other:**

* Bumped the package version from 124 to 125 in `mfile`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added character resistances tracking to monitor and manage character resistance data.

* **Bug Fixes**
  * Improved game event session cleanup logic to properly remove individual ended events instead of clearing all sessions.

* **Chores**
  * Version bumped to 125.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->