### PR TITLE
Add MIT license and credits

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,27 @@
+# Credits
+
+## Code
+
+StickMUDMudletGUI is maintained by the StickMUD community. The code in this repository is
+released under the MIT License — see [LICENSE](LICENSE).
+
+## Icons
+
+The icons in [src/resources](src/resources) are **not** covered by the MIT License. They are
+[Flaticon](https://www.flaticon.com) icons used under the
+[Flaticon Free License](https://www.freepikcompany.com/legal#nav-flaticon), which permits use with
+attribution.
+
+> Icons by [Flaticon](https://www.flaticon.com), a project by Freepik Company.
+
+Anyone redistributing this package, or shipping screenshots and builds derived from it, must keep
+this attribution intact.
+
+## Tooling
+
+- [Mudlet](https://mudlet.org) — the client this package is built for.
+- [DeMuddler](https://github.com/Edru2/DeMuddler) by [@Edru2](https://github.com/Edru2) — used to
+  convert the original `StickMUD.mpackage` into the Lua sources in this repository.
+- [Muddler](https://github.com/demonnic/muddler) by [@demonnic](https://github.com/demonnic) — used
+  by CI to build a release on each pull request.
+- [@gesslar](https://github.com/gesslar) — for [Muddler guidance](https://mud.gesslar.dev/muddler.html).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 StickMUD
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Self-hosted GitHub Actions use [Muddler](https://github.com/demonnic/muddler) to
 * On [StickMUD](https://www.stickmud.com), update the `GMCP_VALUE_CLIENT_GUI_VERSION` in `/include/gmcp_defs.h` to pickup the new version.
 
 See also [this guidance](https://mud.gesslar.dev/muddler.html) from [@gesslar](https://github.com/gesslar).
+
+# License
+The code in this repository is released under the MIT License — see [LICENSE](LICENSE).
+
+The icons in [src/resources](src/resources) are not covered by the MIT License. They are
+[Flaticon](https://www.flaticon.com) icons used under the Flaticon Free License, which requires
+attribution. See [CREDITS.md](CREDITS.md) for the full attribution and license records.


### PR DESCRIPTION
## Summary

Adds an explicit open source license to the repository, which previously had none.

- **LICENSE** — MIT, `Copyright (c) 2020-2026 StickMUD`.
- **CREDITS.md** — Flaticon icon attribution plus credits for Mudlet, DeMuddler and Muddler.
- **README.md** — a License section that carves the icons out of the MIT grant.

## Why MIT rather than Mudlet's GPL2+

This repository is a Mudlet *package* — Lua scripts and assets loaded by Mudlet at runtime — not a derivative of Mudlet's source, so Mudlet's GPL does not extend to it and copyleft is not required. MIT is the common choice for Mudlet community packages and keeps the GUI easy for other package authors to learn from and adapt.

## Icon licensing

Icons under `src/resources` are explicitly **not** covered by the MIT grant. They are Flaticon icons used under the Flaticon Free License, which requires attribution; the stored receipts are `src/resources/license1.html` and `license2.html`.

## Follow-up worth tracking

`src/resources` holds 95 numbered icons, but the two stored receipts cover 77 between them. The other 18, plus the five unnumbered icons (`druid-f/m`, `psionicist-f/m`, `schedule`), have no recorded provenance. Not a blocker for declaring the license, but worth resolving separately — particularly whether the guild icons are original StickMUD artwork, in which case they fall under MIT with the rest of the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project credits, including attribution for third-party icons and contributor acknowledgments.
  * Added licensing information covering the project’s MIT-licensed code and separately licensed assets.
  * Updated the README with links and details about applicable licenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->