### PR TITLE
Fix: NPCs are listed as characters again, not as room inventory

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "127",
+       "version": "128",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/RoomAndInventoryConsoles/Room/Items/CharItemsAddLocationRoom.lua
+++ b/src/scripts/GMCP/RoomAndInventoryConsoles/Room/Items/CharItemsAddLocationRoom.lua
@@ -2,7 +2,12 @@ function CharItemsAddLocationRoom()
   if gmcp.Char.Items.Add.location == "room" then
     local value = gmcp.Char.Items.Add.item
     local highlight = getItemHighlight(value) or ""
-    if value.attrib == "W" then
+    -- "m" is the NPC code. This tested "W" - wearable armour - because that
+    -- is what NPCs used to arrive as: gmcp_d.c classified anything answering
+    -- query_armour() or query_clothing() before it checked for an NPC. The
+    -- daemon tests identity first now, so this follows the documented legend,
+    -- which ItemHighlighting.lua was already using.
+    if value.attrib == "m" then
       roomNPCsTable[value.id] = highlight .. value.name
     else
       roomInvTable[value.id] = highlight .. value.name

--- a/src/scripts/GMCP/RoomAndInventoryConsoles/Room/Items/CharItemsListLocationRoom.lua
+++ b/src/scripts/GMCP/RoomAndInventoryConsoles/Room/Items/CharItemsListLocationRoom.lua
@@ -5,7 +5,12 @@ function CharItemsListLocationRoom()
     if (gmcp.Char.Items.List.items ~= "") then
       for key, value in pairs(gmcp.Char.Items.List.items) do
         local highlight = getItemHighlight(value) or ""
-        if value.attrib == "W" then
+        -- "m" is the NPC code. This tested "W" - wearable armour - because that
+        -- is what NPCs used to arrive as: gmcp_d.c classified anything answering
+        -- query_armour() or query_clothing() before it checked for an NPC. The
+        -- daemon tests identity first now, so this follows the documented legend,
+        -- which ItemHighlighting.lua was already using.
+        if value.attrib == "m" then
           roomNPCsTable[value.id] = highlight .. value.name
         else
           roomInvTable[value.id] = highlight .. value.name


### PR DESCRIPTION
## Problem

NPCs stopped appearing under **Non-Player Characters** in the room console and showed up under **Room Inventory** instead.

The room console decided what was an NPC by testing `attrib == "W"` — the code for wearable armour. That only ever worked because of a precedence bug in the daemon: `classify_item_attrib()` tested `is_wearable` (`query_armour()` / `query_clothing()`) five checks before `is_npc`, so every NPC answering either query arrived tagged `"W"` and landed in the right bucket by accident.

StickMUD now tests identity first, so NPCs arrive as `"m"` and Marech the doorward ended up under Room Inventory with the NPC section empty.

## Fix

Test `"m"`, which is what the legend always said, and what `ItemHighlighting.lua` in this same package has been using all along — it colours `"m"` cyan and `"d"` grey. Half the package followed the documentation and half followed the behaviour; they agree again now.

Corpses stay in room inventory deliberately: `"d"` is a thing you can get, not somebody who is there.

## Changes

- `Room/Items/CharItemsAddLocationRoom.lua` — classify `"m"` as an NPC
- `Room/Items/CharItemsListLocationRoom.lua` — same, for the full list rebuild
- `mfile` — package version 127 → 128


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room and inventory displays so non-player characters are correctly identified and listed separately from ordinary items.
  - Updated character detection to use the current classification information, reducing incorrect item placement in room consoles.

- **Chores**
  - Incremented the package version to 128.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->