### PR TITLE
Fix blank player popup when a sailing route name fails to parse

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "128",
+       "version": "129",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -170,14 +170,26 @@ function GamePlayersInfo()
             -- Extract port names from route (e.g., "Tristeza • Asahi" -> "Tristeza", "Asahi")
             local port1, port2 = route:match("^%s*(.-)%s*•%s*(.-)%s*$")
             -- Use last word of each port name (lowercased) for server's sscanf parsing
-            local port1Short = port1:match("(%S+)$"):lower()
-            local port2Short = port2:match("(%S+)$"):lower()
-            table.insert(rows, {
-                height = smallLineHeight,
+            local port1Short = port1 and port1:match("(%S+)$")
+            local port2Short = port2 and port2:match("(%S+)$")
+            -- Fall back to plain text when the route name is not in the
+            -- expected "Port A • Port B" form, so one bad entry cannot
+            -- abort the whole popup render
+            local content
+            if port1Short and port2Short then
                 content = string.format(
                     [[<center><a href="send:shiptop route %s %s"><font size="2" color="%s">#%d ⛵ %s</font></a></center>]],
-                    port1Short, port2Short, rankColor, rank, route
-                ),
+                    port1Short:lower(), port2Short:lower(), rankColor, rank, route
+                )
+            else
+                content = string.format(
+                    [[<center><font size="2" color="%s">#%d ⛵ %s</font></center>]],
+                    rankColor, rank, route
+                )
+            end
+            table.insert(rows, {
+                height = smallLineHeight,
+                content = content,
                 linkStyle = {rankColor, rankColor, false}
             })
         end


### PR DESCRIPTION
## Problem

The player detail popup renders as a blank shell for any player with `top_sailing` entries, with this in the error console:

```
[event "gmcp.Game.Players.Info"] GamePlayersInfo:175: attempt to index local 'port1' (a nil value)
```

`GamePlayersInfo()` indexed the result of the route pattern match without checking it:

```lua
local port1, port2 = route:match("^%s*(.-)%s*•%s*(.-)%s*$")
local port1Short = port1:match("(%S+)$"):lower()
```

When the match returns nil, the error fires while building `rows` — before `PlayerDetailPopup:resize()` and before any label is created or updated. The handler aborts with nothing drawn, which is why the popup is empty rather than merely missing its sailing rows.

8ff06a8 turned a silent bug into a fatal one. Before it, `port1`/`port2` went straight into `string.format`, so a failed match just printed `nil` in the link href. The match has been failing since the feature landed.

## Root cause is server-side

`gmcp_message()` double-encodes non-ASCII. `json_serialize()` returns json-c's UTF-8 output with each byte held as a separate character, and `gmcp.c` then encodes that as UTF-8 a second time. The U+2022 separator arrives as `C3 A2 C2 80 C2 A2` instead of `E2 80 A2`, so the pattern can never match. Captured from `gmcp.Game.Players.Info.top_sailing`:

```
1    Tristeza â¢ Port of Darkhill
54 72 69 73 74 65 7A 61 20 C3 A2 C2 80 C2 A2 20 50 6F 72 74 20 6F 66 20 44 61 72 6B 68 69 6C 6C
```

Tracked in StickMUD/StickMUD#2437, and that is where it gets fixed. It affects every non-ASCII string in every GMCP package, not just sailing routes.

## What this PR does

Containment only. A route name that does not parse now renders as plain text without the `shiptop` link, instead of taking the rest of the popup down with it. No attempt is made to decode the mojibake client-side — that would paper over the server bug. Once the server is fixed the links come back on their own with no further client change.

Also bumps the package version to 129.

## Testing

- `luac -p` passes on the modified script.
- Exercised the row-building logic against both the correct UTF-8 route name and the observed double-encoded bytes:
  - correct input still produces `send:shiptop route tristeza darkhill`
  - double-encoded input renders `#1 ⛵ Tristeza â¢ Port of Darkhill` with no link, and does not raise
- Confirmed the pre-fix logic reproduces the exact reported error on the double-encoded input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of top-sailing rankings when route names use an unexpected format.
  * Added a safe fallback that shows non-clickable route text instead of producing incorrect links or errors.

* **Chores**
  * Updated the package version from 128 to 129.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->