### PR TITLE
Fix: stop parsing the sailing route separator, and never crash when it fails

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "StickMUD",
        "title": "StickMUDMudletGUI",
        "description": "The official graphical user interface for Mudlet (https://mudlet.org) for StickMUD.",
-       "version": "128",
+       "version": "129",
        "author": "Tamarindo@StickMUD",
        "icon": "https://www.stickmud.com/wp-content/uploads/2020/12/stick-siteicon.png",
        "outputFile": true

--- a/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
+++ b/src/scripts/GMCP/PlayersScrollBox/GamePlayersInfo.lua
@@ -165,19 +165,52 @@ function GamePlayersInfo()
     
     -- Top sailing rows (one per route)
     if info.top_sailing and next(info.top_sailing) then
-        for route, rank in pairs(info.top_sailing) do
-            local rankColor = rank == 1 and "gold" or "silver"
-            -- Extract port names from route (e.g., "Tristeza • Asahi" -> "Tristeza", "Asahi")
-            local port1, port2 = route:match("^%s*(.-)%s*•%s*(.-)%s*$")
-            -- Use last word of each port name (lowercased) for server's sscanf parsing
-            local port1Short = port1:match("(%S+)$"):lower()
-            local port2Short = port2:match("(%S+)$"):lower()
+        -- The server sends an array of {route, rank, num} entries, where num is
+        -- the route number "shiptop <n>" takes. The display name is rendered and
+        -- never parsed, so a separator that arrives mis-decoded costs at most a
+        -- funny-looking label instead of the whole popup.
+        --
+        -- Older servers sent {[display name] = rank} instead. That shape is still
+        -- read, but its link has to be recovered from the name, which is exactly
+        -- the fragile path the array replaces.
+        local entries = {}
+
+        if info.top_sailing[1] then
+            entries = info.top_sailing
+        else
+            for route, rank in pairs(info.top_sailing) do
+                entries[#entries + 1] = {route = route, rank = rank}
+            end
+        end
+
+        for _, entry in ipairs(entries) do
+            local rankColor = entry.rank == 1 and "gold" or "silver"
+            local target = entry.num and ("shiptop " .. entry.num)
+
+            if not target then
+                -- Legacy shape only. Split "Tristeza • Asahi" into port fragments
+                -- for the fuzzy "shiptop route" lookup. Guarded: a match failure
+                -- leaves the row as plain text rather than erroring on a nil.
+                local port1, port2 = entry.route:match("^%s*(.-)%s*•%s*(.-)%s*$")
+                local port1Short = port1 and port1:match("(%S+)$")
+                local port2Short = port2 and port2:match("(%S+)$")
+
+                if port1Short and port2Short then
+                    target = string.format("shiptop route %s %s",
+                        port1Short:lower(), port2Short:lower())
+                end
+            end
+
+            local label = string.format(
+                [[<font size="2" color="%s">#%d ⛵ %s</font>]],
+                rankColor, entry.rank, entry.route
+            )
+
             table.insert(rows, {
                 height = smallLineHeight,
-                content = string.format(
-                    [[<center><a href="send:shiptop route %s %s"><font size="2" color="%s">#%d ⛵ %s</font></a></center>]],
-                    port1Short, port2Short, rankColor, rank, route
-                ),
+                content = target
+                    and string.format([[<center><a href="send:%s">%s</a></center>]], target, label)
+                    or string.format([[<center>%s</center>]], label),
                 linkStyle = {rankColor, rankColor, false}
             })
         end


### PR DESCRIPTION
StickMUD/StickMUD#2437. Ships **before** the matching mudlib change, so this package works against both the current server and the updated one.

## The crash

The player-detail popup rendered completely blank for anyone with sailing rankings:

```
GamePlayersInfo:175: attempt to index local 'port1' (a nil value)
```

`top_sailing` arrived keyed by display name — `"Tristeza • Asahi"` — and the only route back to a `shiptop` link was to split that name on the bullet:

```lua
local port1, port2 = route:match("^%s*(.-)%s*•%s*(.-)%s*$")
local port1Short = port1:match("(%S+)$"):lower()
```

Lua patterns are byte comparisons. When the separator doesn't arrive as exactly `E2 80 A2`, the match returns nil and the unguarded index on the next line takes down **the whole popup**, not just that row.

## The fix

The server now sends the route's own number, so the display name is rendered and never parsed. Each entry is `{route, rank, num}`, and `num` is what `shiptop <n>` already accepts — which also makes the link *exact* instead of a fuzzy port-name search.

Side effect worth having: four North Pole routes get correct links for the first time. Their port tags (`north_pole`) don't substring-match their display names (`North Pole`), so `shiptop route ...` was never going to find them reliably.

## Compatibility

The old `{[display name] = rank}` shape is still read, so this package works against a server that hasn't been updated. Its link still has to be recovered from the name — but that recovery is now guarded, and a row that can't be parsed renders as plain text instead of erroring.

## Verified

Branch logic exercised in isolation across all four combinations:

| Input | Result |
|---|---|
| new shape | `shiptop 12` |
| legacy shape, clean bytes | `shiptop route tristeza asahi` |
| legacy shape, mojibake separator | plain text, no crash — **was the bug** |
| new shape, mojibake label | `shiptop 7`, only the label looks wrong |

The third case reproduces the reported error exactly against the previous code (`attempt to index a nil value (local 'port1')`). `luac -p` clean.

## On the encoding itself

The encoding fault is **not** in this file, and not in the mudlib either. I captured the GMCP frames off the wire and the bytes leaving the server are correct single-encoded UTF-8 (`E2 80 A2`), and the bullet in this file's pattern hexdumps to the same three bytes. Something between the two decodes it differently — most likely the profile's server encoding, since nothing in this package pins it.

That's still worth chasing, but rendering the name instead of parsing it means it can no longer break the popup. `GamePlayersInfo.lua` was the only file in this package that pattern-matched a non-ASCII literal against server data, which is exactly why this was the one place it surfaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the top-sailing display to support the latest server-provided route data.
  - Added direct navigation links for sailing rankings when route details are available.

- **Bug Fixes**
  - Preserved compatibility with older route data formats.
  - Prevented malformed or incomplete route information from causing display errors; affected entries now appear as plain text.

- **Chores**
  - Updated the package version from 128 to 129.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->